### PR TITLE
allow multi-threaded indexing

### DIFF
--- a/src/net/sf/samtools/TabixReader.java
+++ b/src/net/sf/samtools/TabixReader.java
@@ -70,7 +70,7 @@ public class TabixReader implements LineReader, Iterable<String> {
   static final int TAD_MIN_CHUNK_GAP = 32768;
   static final int TAD_LIDX_SHIFT = 14;
 
-  protected static Path index;
+  protected Path index;
 
   class TPair64 implements Comparable<TPair64> {
     long u, v;


### PR DESCRIPTION
Multi-threaded indexing failed because path to index was static and hence shared between all instances of this class. 

Results in many different errors.